### PR TITLE
refactor: API 응답 포맷 개선

### DIFF
--- a/src/main/java/com/greedy/meetlink/common/ApiResponse.java
+++ b/src/main/java/com/greedy/meetlink/common/ApiResponse.java
@@ -1,0 +1,36 @@
+package com.greedy.meetlink.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse<T> {
+    private final boolean status;
+    private final T result;
+    private final String code;
+    private final String message;
+
+    public static <T> ApiResponse<T> success() {
+        return success(null);
+    }
+
+    public static <T> ApiResponse<T> success(T result) {
+        return new ApiResponse<>(true, result, null, null);
+    }
+
+    public static <T> ApiResponse<T> error(ResponseCode code) {
+        return error(code, code.getMessage());
+    }
+
+    public static <T> ApiResponse<T> error(ResponseCode code, T result) {
+        return new ApiResponse<>(false, result, code.name(), code.getMessage());
+    }
+
+    public static <T> ApiResponse<T> error(ResponseCode code, String message) {
+        return new ApiResponse<>(false, null, code.name(), message);
+    }
+}

--- a/src/main/java/com/greedy/meetlink/common/ResponseCode.java
+++ b/src/main/java/com/greedy/meetlink/common/ResponseCode.java
@@ -1,0 +1,27 @@
+package com.greedy.meetlink.common;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ResponseCode {
+    // 400
+    INVALID_REQUEST("잘못된 요청입니다."),
+    INVALID_REQUEST_BODY("요청 본문이 비어있거나 형식이 잘못되었습니다."),
+    VALIDATION_FAILED("요청 값이 올바르지 않습니다."),
+
+    // 401
+    UNAUTHORIZED("인증이 필요합니다."),
+
+    // 403
+    FORBIDDEN("접근 권한이 없습니다."),
+
+    // 404
+    NOT_FOUND("대상을 찾을 수 없습니다."),
+
+    // 500
+    INTERNAL_ERROR("서버 내부 오류가 발생했습니다.");
+
+    private final String message;
+}

--- a/src/main/java/com/greedy/meetlink/common/dto/response/ErrorResponse.java
+++ b/src/main/java/com/greedy/meetlink/common/dto/response/ErrorResponse.java
@@ -1,7 +1,0 @@
-package com.greedy.meetlink.common.dto.response;
-
-import java.util.Map;
-import lombok.Builder;
-
-@Builder
-public record ErrorResponse(int status, String message, Map<String, String> errors) {}

--- a/src/main/java/com/greedy/meetlink/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/greedy/meetlink/common/exception/GlobalExceptionHandler.java
@@ -1,74 +1,52 @@
 package com.greedy.meetlink.common.exception;
 
-import com.greedy.meetlink.common.dto.response.ErrorResponse;
+import com.greedy.meetlink.common.ApiResponse;
+import com.greedy.meetlink.common.ResponseCode;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.FieldError;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@Slf4j // 로깅을 위한 어노테이션 추가
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-
-    /** 비즈니스 예외 (MeetingNotFoundException) */
     @ExceptionHandler(MeetingNotFoundException.class)
-    public ResponseEntity<ErrorResponse> handleMeetingNotFoundException(
-            MeetingNotFoundException ex) {
-        log.warn("Meeting not found: {}", ex.getMessage());
-
-        return createErrorResponse(HttpStatus.NOT_FOUND, ex.getMessage(), null);
+    public ResponseEntity<ApiResponse<?>> handleMeetingNotFoundException(
+            MeetingNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.error(ResponseCode.NOT_FOUND, e.getMessage()));
     }
 
-    /** Bean Validation 유효성 검증 실패 */
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponse> handleValidationException(
-            MethodArgumentNotValidException ex) {
+    public ResponseEntity<ApiResponse<?>> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException e) {
         Map<String, String> errors = new HashMap<>();
-        ex.getBindingResult()
-                .getAllErrors()
-                .forEach(
-                        error -> {
-                            String fieldName = ((FieldError) error).getField();
-                            String errorMessage = error.getDefaultMessage();
-                            errors.put(fieldName, errorMessage);
-                        });
 
-        log.warn("Validation failed: {}", errors);
+        e.getBindingResult()
+                .getFieldErrors()
+                .forEach((error) -> errors.put(error.getField(), error.getDefaultMessage()));
 
-        return createErrorResponse(HttpStatus.BAD_REQUEST, "입력값 검증에 실패했습니다.", errors);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error(ResponseCode.VALIDATION_FAILED, errors));
     }
 
-    /** 잘못된 인자 전달 */
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(
-            IllegalArgumentException ex) {
-        log.warn("Illegal argument: {}", ex.getMessage());
-
-        return createErrorResponse(HttpStatus.BAD_REQUEST, ex.getMessage(), null);
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<?>> handleHttpMessageNotReadableException(
+            HttpMessageNotReadableException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error(ResponseCode.INVALID_REQUEST_BODY));
     }
 
-    /** 서버 내부 오류 (예상치 못한 예외) */
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleGeneralException(Exception ex) {
-        log.error("Unexpected server error occurred: ", ex);
+    public ResponseEntity<ApiResponse<?>> handleFallbackException(Exception e) {
+        log.error("Unexpected server error occurred: ", e);
 
-        return createErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.", null);
-    }
-
-    /** 중복 코드를 줄이기 위한 공통 응답 생성 메서드 */
-    private ResponseEntity<ErrorResponse> createErrorResponse(
-            HttpStatus status, String message, Map<String, String> errors) {
-        ErrorResponse response =
-                ErrorResponse.builder()
-                        .status(status.value())
-                        .message(message)
-                        .errors(errors)
-                        .build();
-        return ResponseEntity.status(status).body(response);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error(ResponseCode.INTERNAL_ERROR));
     }
 }

--- a/src/main/java/com/greedy/meetlink/common/exception/MeetingNotFoundException.java
+++ b/src/main/java/com/greedy/meetlink/common/exception/MeetingNotFoundException.java
@@ -1,8 +1,7 @@
 package com.greedy.meetlink.common.exception;
 
 public class MeetingNotFoundException extends RuntimeException {
-
-    public MeetingNotFoundException(String code) {
-        super("모임을 찾을 수 없습니다: " + code);
+    public MeetingNotFoundException() {
+        super("모임을 찾을 수 없습니다.");
     }
 }

--- a/src/main/java/com/greedy/meetlink/meeting/controller/MeetingController.java
+++ b/src/main/java/com/greedy/meetlink/meeting/controller/MeetingController.java
@@ -1,13 +1,12 @@
 package com.greedy.meetlink.meeting.controller;
 
+import com.greedy.meetlink.common.ApiResponse;
 import com.greedy.meetlink.meeting.dto.request.MeetingCreateRequest;
 import com.greedy.meetlink.meeting.dto.request.MeetingUpdateRequest;
 import com.greedy.meetlink.meeting.dto.response.MeetingResponse;
 import com.greedy.meetlink.meeting.service.MeetingService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -21,51 +20,31 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/meetings")
 @RequiredArgsConstructor
 public class MeetingController {
-
     private final MeetingService meetingService;
 
     @GetMapping("/{code}")
-    public ResponseEntity<MeetingResponse> getMeetingDetail(@PathVariable String code) {
-        MeetingResponse response = meetingService.getMeetingDetail(code);
-        return ResponseEntity.ok(response);
+    public ApiResponse<MeetingResponse> getMeeting(@PathVariable String code) {
+        MeetingResponse response = meetingService.get(code);
+        return ApiResponse.success(response);
     }
 
-    /**
-     * 모임 생성
-     *
-     * @param request 모임 생성 요청
-     * @return 생성된 모임 정보
-     */
     @PostMapping
-    public ResponseEntity<MeetingResponse> createMeeting(
+    public ApiResponse<MeetingResponse> createMeeting(
             @Valid @RequestBody MeetingCreateRequest request) {
         MeetingResponse response = meetingService.create(request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        return ApiResponse.success(response);
     }
 
-    /**
-     * 모임 수정
-     *
-     * @param code 모임 code
-     * @param request 모임 수정 요청
-     * @return 수정된 모임 정보
-     */
     @PutMapping("/{code}")
-    public ResponseEntity<MeetingResponse> updateMeeting(
+    public ApiResponse<MeetingResponse> updateMeeting(
             @PathVariable String code, @Valid @RequestBody MeetingUpdateRequest request) {
         MeetingResponse response = meetingService.update(code, request);
-        return ResponseEntity.ok(response);
+        return ApiResponse.success(response);
     }
 
-    /**
-     * 모임 삭제
-     *
-     * @param code 모임 code
-     * @return 204 No Content
-     */
     @DeleteMapping("/{code}")
-    public ResponseEntity<Void> deleteMeeting(@PathVariable String code) {
+    public ApiResponse<Void> deleteMeeting(@PathVariable String code) {
         meetingService.delete(code);
-        return ResponseEntity.noContent().build();
+        return ApiResponse.success();
     }
 }

--- a/src/main/java/com/greedy/meetlink/meeting/service/MeetingService.java
+++ b/src/main/java/com/greedy/meetlink/meeting/service/MeetingService.java
@@ -14,18 +14,19 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class MeetingService {
 
     private static final int MAX_CODE_GENERATION_ATTEMPTS = 10;
     private final MeetingRepository meetingRepository;
 
-    /**
-     * 모임 생성
-     *
-     * @param request 모임 생성 요청 DTO (유효성 검증은 DTO 레벨에서 완료됨)
-     * @return 생성된 모임 응답 DTO
-     */
+    @Transactional(readOnly = true)
+    public MeetingResponse get(String code) {
+        Meeting meeting =
+                meetingRepository.findByCode(code).orElseThrow(MeetingNotFoundException::new);
+
+        return MeetingResponse.from(meeting);
+    }
+
     @Transactional
     public MeetingResponse create(MeetingCreateRequest request) {
 
@@ -47,19 +48,10 @@ public class MeetingService {
         return MeetingResponse.from(savedMeeting);
     }
 
-    /**
-     * 모임 수정
-     *
-     * @param code 모임 code
-     * @param request 모임 수정 요청 DTO
-     * @return 수정된 모임 응답 DTO
-     */
     @Transactional
     public MeetingResponse update(String code, MeetingUpdateRequest request) {
         Meeting meeting =
-                meetingRepository
-                        .findByCode(code)
-                        .orElseThrow(() -> new MeetingNotFoundException(code));
+                meetingRepository.findByCode(code).orElseThrow(MeetingNotFoundException::new);
 
         meeting.update(
                 request.getName(),
@@ -72,25 +64,13 @@ public class MeetingService {
         return MeetingResponse.from(meeting);
     }
 
-    /**
-     * 모임 삭제
-     *
-     * @param code 모임 code
-     */
     @Transactional
     public void delete(String code) {
         Meeting meeting =
-                meetingRepository
-                        .findByCode(code)
-                        .orElseThrow(() -> new MeetingNotFoundException(code));
+                meetingRepository.findByCode(code).orElseThrow(MeetingNotFoundException::new);
         meetingRepository.deleteById(meeting.getId());
     }
 
-    /**
-     * 중복되지 않는 고유한 모임 코드 생성
-     *
-     * @return 생성된 코드
-     */
     private String generateUniqueCode() {
         for (int i = 0; i < MAX_CODE_GENERATION_ATTEMPTS; i++) {
             String code = MeetingCodeGenerator.generateCode();
@@ -99,15 +79,5 @@ public class MeetingService {
             }
         }
         throw new MeetingCodeGenerationException();
-    }
-
-    @Transactional
-    public MeetingResponse getMeetingDetail(String code) {
-        Meeting meeting =
-                meetingRepository
-                        .findByCode(code)
-                        .orElseThrow(() -> new MeetingNotFoundException(code));
-
-        return MeetingResponse.from(meeting);
     }
 }

--- a/src/test/java/com/greedy/meetlink/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/greedy/meetlink/meeting/service/MeetingServiceTest.java
@@ -44,7 +44,7 @@ class MeetingServiceTest {
         given(meetingRepository.findByCode(code)).willReturn(Optional.of(mockMeeting));
 
         // when
-        MeetingResponse response = meetingService.getMeetingDetail(code);
+        MeetingResponse response = meetingService.get(code);
 
         // then
         // 기본 정보 검증
@@ -63,7 +63,7 @@ class MeetingServiceTest {
         given(meetingRepository.findByCode(wrongCode)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> meetingService.getMeetingDetail(wrongCode))
+        assertThatThrownBy(() -> meetingService.get(wrongCode))
                 .isInstanceOf(MeetingNotFoundException.class);
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- X
---
## ✨ 작업 내용
- API 응답 형태를 공통 형태로 재정의했습니다. 응답 예시는 다음과 같습니다.
```json
{
    "status": false,
    "code": "NOT_FOUND",
    "message": "모임을 찾을 수 없습니다."
}
```
```json
{
    "status": true,
    "result": {
        "code": "KVy9flYo",
        "createdAt": "2026-02-16T23:44:33.37543",
        "enablePlaceRecommendation": true,
        "enableTimeRecommendation": false,
        "id": 1,
        "name": "테스트",
        "timeAvailabilityType": "SPECIFIC_DATE",
        "timeRangeEnd": "12:00:00",
        "timeRangeStart": "11:00:00",
        "updatedAt": "2026-02-16T23:44:33.37543"
    }
}
```
```json
{
    "status": false,
    "code": "VALIDATION_FAILED",
    "message": "요청 값이 올바르지 않습니다.",
    "result": {
        "enablePlaceRecommendation": "장소 추천 사용 여부는 필수입니다.",
        "enableTimeRecommendation": "시간 추천 사용 여부는 필수입니다."
    }
}
```
---
## 👀 리뷰 포인트 (선택)
- X
---