### PR TITLE
chore: 개발 서버 postgres 포트 expose

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,8 @@
 services:
   postgres:
     container_name: meetlink-db-dev
+    ports:
+      - "5432:5432"
   app:
     container_name: meetlink-app-dev
   nginx:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       DB_PASSWORD: ${DB_PASSWORD}
     profiles: ["app"]
   nginx:
+    container_name: meetlink-nginx
     image: nginx:alpine
     restart: always
     ports:


### PR DESCRIPTION
## 🔗 관련 이슈
- X
---
## ✨ 작업 내용
- 개발 서버 내 postgres를 호스트에서 접근할 수 있도록 포트를 expose했습니다.
---
## 👀 리뷰 포인트 (선택)
-  보안 상 다른 네트워크 -> 호스트로는 접속할 수 없으므로, 로컬에서 개발 DB에 접속하고자 한다면 SSH 터널링을 통해서 접근하는 것을 권장합니다.
    - `ssh -L 5431:localhost:5432 -N -i <키파일> ubuntu@<인스턴스IP>`
    - 이후 localhost:5431으로 접속