### PR TITLE
chore: API 도메인 변경

### DIFF
--- a/config/nginx.dev.conf
+++ b/config/nginx.dev.conf
@@ -1,16 +1,15 @@
 server {
     listen 443 ssl;
-    server_name dev.meetlink.now;
+    server_name api.dev.meetlink.now;
 
     ssl_certificate /etc/nginx/certs/cert.pem;
     ssl_certificate_key /etc/nginx/certs/key.pem;
 
-    location /api/ {
-        proxy_pass http://backend:8080/;
+    location / {
+        proxy_pass http://backend:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Prefix /api;
     }
 }

--- a/config/nginx.prod.conf
+++ b/config/nginx.prod.conf
@@ -1,12 +1,12 @@
 server {
     listen 443 ssl;
-    server_name meetlink.now;
+    server_name api.meetlink.now;
 
     ssl_certificate /etc/nginx/certs/cert.pem;
     ssl_certificate_key /etc/nginx/certs/key.pem;
 
-    location /api/ {
-        proxy_pass http://backend:8080/;
+    location / {
+        proxy_pass http://backend:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## 🔗 관련 이슈
- X
---
## ✨ 작업 내용
- 프론트엔드 도메인 연동 간 중복 문제가 있어 백엔드 API 주소를 변경했습니다.
---
## 👀 리뷰 포인트 (선택)
- X
