### PR TITLE
chore: SSL 인증서 미지원으로 인한 API 도메인 업데이트

### DIFF
--- a/config/nginx.dev.conf
+++ b/config/nginx.dev.conf
@@ -1,6 +1,6 @@
 server {
     listen 443 ssl;
-    server_name api.dev.meetlink.now;
+    server_name api-dev.meetlink.now;
 
     ssl_certificate /etc/nginx/certs/cert.pem;
     ssl_certificate_key /etc/nginx/certs/key.pem;


### PR DESCRIPTION
## 🔗 관련 이슈
- X
---
## ✨ 작업 내용
- Cloudflare 측에서 2차 서브도메인에 대한 SSL 인증서 미지원으로 인해 부득이하게 API 도메인 주소를 업데이트했습니다.
---
## 👀 리뷰 포인트 (선택)
- X
