### PR TITLE
refactor: motis config 프로젝트 내 위치한 파일 사용하도록 수정

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -6,7 +6,6 @@ services:
   motis-import:
     volumes:
       - ./config/motis/input:/input
-      - ./config/motis/config.yml:/config.yml
       - ./motis-data:/data
   motis:
     container_name: motis-local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     profiles: ["import"]
     volumes:
       - /srv/meetlink/motis/input:/input
-      - /srv/meetlink/motis/config.yml:/config.yml
+      - ./config/motis/config.yml:/config.yml
       - motis-data:/data
     command: /motis import
   motis:


### PR DESCRIPTION
## 🔗 관련 이슈
- X
---
## ✨ 작업 내용
- MOTIS import 과정에서 사용할 config.yml을 프로젝트 내 위치한 파일으로 사용하도록 수정했습니다.
---
## 👀 리뷰 포인트 (선택)
- X
