### PR TITLE
fix: 시간 후보 산출 안되는 오류 수정

### DIFF
--- a/src/main/java/com/greedy/meetlink/availability/service/TimeAvailabilityService.java
+++ b/src/main/java/com/greedy/meetlink/availability/service/TimeAvailabilityService.java
@@ -12,6 +12,7 @@ import com.greedy.meetlink.common.exception.InvalidTimeAvailabilityException;
 import com.greedy.meetlink.common.validation.ParticipantValidator;
 import com.greedy.meetlink.meeting.entity.Meeting;
 import com.greedy.meetlink.participant.entity.Participant;
+import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
@@ -28,6 +29,7 @@ public class TimeAvailabilityService {
     private final TimeAvailabilityRepository timeAvailabilityRepository;
     private final ParticipantValidator participantValidator;
     private final ApplicationEventPublisher eventPublisher;
+    private final EntityManager entityManager;
 
     @Transactional
     public void submit(String meetingCode, String token, TimeAvailabilityRequest request) {
@@ -37,14 +39,20 @@ public class TimeAvailabilityService {
 
         // 빈 요청이면 기존 데이터 삭제 후 제출 상태 초기화
         if (request.getAvailabilities() == null || request.getAvailabilities().isEmpty()) {
-            timeAvailabilityRepository.deleteByMeetingAndParticipant(meeting, participant);
             participant.unmarkTimeSubmitted();
+            entityManager.flush(); // 명시적으로 변경 사항 flush
+
+            timeAvailabilityRepository.deleteByMeetingAndParticipant(meeting, participant);
             eventPublisher.publishEvent(new TimeAvailabilityClearedEvent(meetingCode));
             return;
         }
 
         // 모임 타입 검증
         validateByMeetingType(meeting, request);
+
+        // 시간 제출 여부 체크
+        participant.markTimeSubmitted();
+        entityManager.flush(); // 명시적으로 변경 사항 flush
 
         // 기존 데이터 제거
         timeAvailabilityRepository.deleteByMeetingAndParticipant(meeting, participant);
@@ -66,9 +74,6 @@ public class TimeAvailabilityService {
                         .toList();
 
         timeAvailabilityRepository.saveAll(entities);
-
-        // 시간 제출 여부 체크
-        participant.markTimeSubmitted();
 
         eventPublisher.publishEvent(new TimeAvailabilitySubmittedEvent(meetingCode));
     }


### PR DESCRIPTION
## 🔗 관련 이슈
- X
---
## ✨ 작업 내용
### Cause
- 관련 PR: #75
- 해당 PR에서 `deleteByMeetingAndParticipant` 메소드에 `@Modifying(clearAutomatically = true)`를 추가하면서 버그가 발생했습니다.
- `clearAutomatically = true`는 JPQL DELETE 실행 후 `entityManager.clear()`를 호출해 영속성 컨텍스트 전체를 초기화하는데, 이로 인해 기존 Participant 엔티티가 detach 되어서 이후 `markTimeSubmitted()`, `unmarkTimeSubmitted()` 변경이 JPA dirty checking  대상에서 제외되어 `timeSubmittedAt`이 DB에 반영되지 않았습니다.
- 그 결과 `findLastTimeSubmission`이 항상 빈 값을 반환하여 시간 후보 계산이 항상 skip되는 현상이 발생했습니다.
### Workaround
- Participant 상태 변경 후 `entityManager.flush()`를 명시적으로 호출하여 `clearAutomatically`가 컨텍스트를 초기화하기 이전에 변경 사항을 DB에 먼저 반영하도록 수정했습니다.
---
## 👀 리뷰 포인트 (선택)
- X
